### PR TITLE
Removes uglify from dev task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,7 +45,6 @@ gulp.task('javascript', function() {
       .pipe(source('liberator.js'))
       .pipe(buffer())
       .pipe(sourcemaps.init({loadMaps: true}))
-      .pipe(uglify())
       .pipe(sourcemaps.write('./'))
       .pipe(gulp.dest('./app/dist/'));
   };


### PR DESCRIPTION
Uglify step added ~2s to compile times, plus breaks source mapping.
Should be implemented only in production build step
